### PR TITLE
Add support for basic auth

### DIFF
--- a/check_ganeti
+++ b/check_ganeti
@@ -39,7 +39,7 @@ my $np = Nagios::Plugin->new(
     usage => "Usage: %s [ -H|--hostname=<hostname>] " . "[ -p|--port=<port> ] " . "[ -U|--username=<username> ] " . "[ -P|--password=<password> ]",
     shortname => 'Check Ganeti cluster health',
     url       => 'https://github.com/credativ/check_ganeti',
-    version   => '0.1',
+    version   => '0.2',
     license   => 'This plugin is free software, and comes with ABSOLUTELY
 NO WARRANTY. It may be used, redistributed and/or modified under
 the terms of the BSD 3-clause license.',

--- a/check_ganeti
+++ b/check_ganeti
@@ -36,7 +36,7 @@ use Nagios::Plugin;
 use Date::Parse;
 
 my $np = Nagios::Plugin->new(
-    usage => "Usage: %s [ -H|--hostname=<hostname>] " . "[ -p|--port=<port> ]",
+    usage => "Usage: %s [ -H|--hostname=<hostname>] " . "[ -p|--port=<port> ] " . "[ -U|--username=<username> ] " . "[ -P|--password=<password> ]",
     shortname => 'Check Ganeti cluster health',
     url       => 'https://github.com/credativ/check_ganeti',
     version   => '0.1',
@@ -57,6 +57,24 @@ $np->add_arg(
     default => 5080,
 );
 
+$np->add_arg(
+    spec    => 'username|U=s',
+    help    => 'Username for basic authentication',
+    default => undef,
+);
+
+$np->add_arg(
+    spec    => 'password|P=s',
+    help    => 'Password for basic authentication',
+    default => undef,
+);
+
+$np->add_arg(
+    spec    => 'realm|R=s',
+    help    => 'Realm for basic authentication (default: "%s")',
+    default => 'Ganeti Remote API',
+);
+
 $np->getopts;
 
 my $url = sprintf( 'https://%s:%d/', $np->opts->hostname, $np->opts->port );
@@ -64,6 +82,14 @@ my $url = sprintf( 'https://%s:%d/', $np->opts->hostname, $np->opts->port );
 my $ua = new LWP::UserAgent;
 $ua->default_header( 'Accept' => 'application/json' );
 $ua->ssl_opts( verify_hostname => 0, SSL_verify_mode => 0 );
+if ($np->opts->username && $np->opts->password) {
+    $ua->credentials(
+        $np->opts->hostname . ':' . $np->opts->port,
+        $np->opts->realm,
+        $np->opts->username,
+        $np->opts->password
+    );
+}
 
 # get general information about the cluster
 


### PR DESCRIPTION
When trying to use this check to monitor a small Ganeti cluster based on Debian Jessie, I noticed that the RAPI defaults to require basic authentication. This pull request adds additional, optional parameters to the check script which allow to pass username, password and an optional realm for basic authentication in the RAPI calls.